### PR TITLE
ci: Fix publish action to allow publish commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,9 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   publish:


### PR DESCRIPTION
Add write permissions to publish workflow to allow commits and issues to be created by semantic-release